### PR TITLE
fix: 修复字体请求路径错误导致无法解析的bug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -269,12 +269,12 @@ fn App() -> Element {
             font-weight: 900;
             font-style: normal;
         }}"#,
-        FONT_THIN.bundled().bundled_path(),
-        FONT_LIGHT.bundled().bundled_path(),
-        FONT_REGULAR.bundled().bundled_path(),
-        FONT_MEDIUM.bundled().bundled_path(),
-        FONT_BOLD.bundled().bundled_path(),
-        FONT_BLACK.bundled().bundled_path(),
+        FONT_THIN.to_string(),
+        FONT_LIGHT.to_string(),
+        FONT_REGULAR.to_string(),
+        FONT_MEDIUM.to_string(),
+        FONT_BOLD.to_string(),
+        FONT_BLACK.to_string(),
     );
 
     let font_face_bender = format!(
@@ -285,7 +285,7 @@ fn App() -> Element {
             font-weight: normal;
             font-style: normal;
         }}"#,
-        FONT_BENDER.bundled().bundled_path()
+        FONT_BENDER.to_string()
     );
 
     let avatar_background_bundled_path = AVATAR_BACKGROUND.bundled();


### PR DESCRIPTION
fix #14 

请求字体资源的路径是 `http://127.0.0.1:8080/HarmonyOS_Sans_Bold-dxh42f2bc4c23c2e71.ttf`
<img width="1656" height="258" alt="Image" src="https://github.com/user-attachments/assets/d255bbac-da3e-4868-8297-d6088d0e7e87" />

而打包后的资源在 `\target\dx\baker-dx\debug\web\public\assets` 下，导致路由解析错误。

原因是 `.bundled().bundled_path()` 只返回了个文件名缺少了 `/assets/` 路径

https://github.com/Wanye-7300/baker-dx/blob/2cc7b2eb3aa780ddd0429c14fb34425f6b0b0300/src/main.rs#L272-L277
https://github.com/Wanye-7300/baker-dx/blob/2cc7b2eb3aa780ddd0429c14fb34425f6b0b0300/src/main.rs#L288

改用 `.to_string()` 返回从根目录出发的绝对路径即可。

除此之外，在排查过程中注意到其他图片文件、ICO 图标都是直接用的 `.bundled().bundled_path()`，都只解析成文件名。
之所以能正常使用是因为直接传递给 Dioxus 的会自动处理（如 `document::Link::href`、`document::Style`），其他的都定义成了 CSS 变量
https://github.com/Wanye-7300/baker-dx/blob/2cc7b2eb3aa780ddd0429c14fb34425f6b0b0300/src/main.rs#L318
然后这些变量又只在 `/assets/main.css` 中被引用，经过 CSS 变量替换后，就变成相对于 `/assets/main.css`  的路径引用，刚好补上了前面的 `/assets/`（

如果不是有意为之的话建议也改用 `.to_string()`，返回以 `/assets/` 开头的路径在 CSS 中解析为绝对路径，不会变成 `/assets/assets/` 套娃（